### PR TITLE
REPLACE 'colored' gem by 'colorize'

### DIFF
--- a/lib/shog/formatter.rb
+++ b/lib/shog/formatter.rb
@@ -1,5 +1,5 @@
 require 'active_support/tagged_logging'
-require 'colored'
+require 'colorize'
 
 module Shog
 

--- a/shog.gemspec
+++ b/shog.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'rails', '>= 4'
-  spec.add_dependency 'colored', '~> 1.2'
+  spec.add_dependency 'colorize', '>= 0.8'
   spec.required_ruby_version = '>= 1.9.2'
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
The `colored` gem has not been updated for 8 years and is uncompatible
with the `colorize` one. It would be a better idea to drop it and only
rely on `colorize`.
Both gems have a similar API so there is no breaking changes so far.

Related links:
- [colored](https://github.com/defunkt/colored) gem
- [colorize](https://github.com/fazibear/colorize) gem

Closes #14 